### PR TITLE
Bump pfring from 7.4.0 to 7.6.0-bg

### DIFF
--- a/libs/libpfring/Makefile
+++ b/libs/libpfring/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=libpfring
-PKG_VERSION:=7.4.0
+PKG_VERSION:=7.6.0-bg
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/ntop/PF_RING/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=e1c9cb44d8072854220f493c56fa5cba99a6b8336883939dc18b3e30c2954b68
+PKG_SOURCE_URL:=https://codeload.github.com/nieuwejaar/PF_RING/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=93d6fc6d434faaa33b51b86cb7512b4b963509822e8e38e2eba28085bd3872b0
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/PF_RING-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>

--- a/libs/libpfring/patches/0002-fix-march-native.patch
+++ b/libs/libpfring/patches/0002-fix-march-native.patch
@@ -1,11 +1,11 @@
 --- a/userland/configure
 +++ b/userland/configure
-@@ -3291,7 +3291,7 @@ SYS_LIBS=""
- VER=`cat ../kernel/linux/pf_ring.h | grep RING_VERSION | head -1 | cut -d '"' -f 2`
- MAJOR_VER=`cat ../kernel/linux/pf_ring.h | grep RING_VERSION | head -1 | cut -d '"' -f 2 | cut -d '.' -f 1`
+@@ -3321,7 +3321,7 @@
+ fi
  
--NATIVE=`$CC -c -Q -march=native --help=target| grep "march" | xargs | cut -d ' ' -f 2`
-+NATIVE=`$CC -c -Q --help=target| grep "march" | xargs | cut -d ' ' -f 2`
- if test -f "lib/libs/libpfring_zc_x86_64_$NATIVE.a"; then
-   CFLAGS="-march=native -mtune=native $CFLAGS"
-   LIBARCH="_$NATIVE"
+ if test "x$enable_archopt" != "xno"; then
+-    NATIVE=`$CC -c -Q -march=native --help=target| grep "march" | xargs | cut -d ' ' -f 2`
++    NATIVE=`$CC -c -Q --help=target| grep "march" | xargs | cut -d ' ' -f 2`
+ 
+   if test "$NATIVE" = haswell; then
+     NATIVE="core-avx2"


### PR DESCRIPTION
Change the PF_RING source from 7.4 mainline to my 7.6 branch with the ifindex fix applied.

There is also a tweak to an existing OpenWRT patch, to account for a change in the upsteam PF_RING source.